### PR TITLE
Add mugshot display and customization CVars

### DIFF
--- a/ZSCRIPT.zs
+++ b/ZSCRIPT.zs
@@ -92,7 +92,11 @@ class BuddyWatchHandler : StaticEventHandler
 		}
 		
 		string suffix = "ST"..(4 - min(plr.health / 20, 4)).."1";
-		if (plr.health < 1)
+		if (plr.player.cheats & (CF_GODMODE | CF_GODMODE2) || plr.binvulnerable)
+		{
+			suffix = "GOD0";
+		}
+		else if (plr.health < 1)
 		{
 			suffix = "DEAD0";
 		}

--- a/ZSCRIPT.zs
+++ b/ZSCRIPT.zs
@@ -27,26 +27,79 @@ class BuddyWatchHandler : StaticEventHandler
 			}
 
 			StatusBar.DrawString(MainFont, plr.player.GetUserName(), off, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_TEXT_ALIGN_RIGHT, scale: (0.75, 0.75));
-			DrawHealthTicker(StatusBar, plr, (off.x - 8, off.y + 14), StatusBar.DI_SCREEN_RIGHT_TOP);
-			StatusBar.DrawString(MainFont, StatusBar.FormatNumber(int(plr.enc), 1, 8), (off.x - 16, off.y + 8), StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_TEXT_ALIGN_RIGHT, plr.overloaded < 0.8 ? Font.CR_OLIVE : plr.overloaded > 1.6 ? Font.CR_RED : Font.CR_GOLD, scale: (0.75, 0.75));
+			int elementsoff = 4;
+			if (cvar.getcvar("cl_buddyekg", players[consoleplayer]).getbool())
+			{
+				DrawHealthTicker(StatusBar, plr, (off.x - (elementsoff + 4), off.y + 14), StatusBar.DI_SCREEN_RIGHT_TOP);
+				elementsoff += 8;
+			}
 			
-			double addOff = off.y + 7 + MainFont.mFont.GetHeight();
+			if (cvar.getcvar("cl_buddybulk", players[consoleplayer]).getbool())
+			{
+				StatusBar.DrawString(MainFont, StatusBar.FormatNumber(int(plr.enc), 1, 8), (off.x - (elementsoff + 2), off.y + 8), StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_TEXT_ALIGN_RIGHT, plr.overloaded < 0.8 ? Font.CR_OLIVE : plr.overloaded>1.6 ? Font.CR_RED : Font.CR_GOLD, scale: (0.75, 0.75));
+				double addOff = off.y + 7 + MainFont.mFont.GetHeight();
 
-			StatusBar.Fill(Color(128, 96, 96, 96), off.x - 14, addOff + 1, -20, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
-			StatusBar.Fill(Color(128, 96, 96, 96), off.x - 14, addOff + 2, -1, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
+				StatusBar.Fill(Color(128, 96, 96, 96), off.x - elementsoff, addOff + 1, -20, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
+				StatusBar.Fill(Color(128, 96, 96, 96), off.x - elementsoff, addOff + 2, -1, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
 
-			StatusBar.Fill(plr.player.GetDisplayColor() | 0xFF000000, off.x - 15, addOff + 2, -min(plr.maxpocketspace, plr.pocketenc) * 19 / plr.maxpocketspace, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
+				StatusBar.Fill(plr.player.GetDisplayColor() | 0xFF000000, off.x - (elementsoff + 1), addOff + 2, -min(plr.maxpocketspace, plr.pocketenc) * 19 / plr.maxpocketspace, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
 
-			bool overenc = plr.flip && plr.pocketenc > plr.maxpocketspace;
-			StatusBar.Fill(overenc ? Color(255, 216, 194, 42) : Color(128, 96, 96, 96), off.x - 34, addOff + 2, overenc ? 2 : 1, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
-			StatusBar.Fill(Color(128, 96, 96, 96), off.x - 14, addOff + 3, -20, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
-
+				bool overenc = plr.flip && plr.pocketenc > plr.maxpocketspace;
+				StatusBar.Fill(overenc ? Color(255, 216, 194, 42) : Color(128, 96, 96, 96), off.x - (elementsoff + 20), addOff + 2, overenc ? 2 : 1, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
+				StatusBar.Fill(Color(128, 96, 96, 96), off.x - elementsoff, addOff + 3, -20, 1, StatusBar.DI_SCREEN_RIGHT_TOP | StatusBar.DI_ITEM_RIGHT);
+				
+				elementsoff += 20;
+			}
+			
+			if (cvar.getcvar("cl_buddymug", players[consoleplayer]).getbool())
+			{
+				drawmugshot(statusbar, plr, (off.x - (elementsoff + 10), off.y + 20), statusbar.DI_SCREEN_RIGHT_TOP);
+			}
+			
 			off.y += 22;
 		}
 
 		StatusBar.FullscreenOffsets = OriginalFullscreen;
 	}
 
+	private ui void drawmugshot(basestatusbar sb, hdplayerpawn plr, vector2 drawpos, int flags)
+	{
+		string mug = "";
+		if(plr.mugshot==HDMUGSHOT_DEFAULT)
+		{
+			switch(plr.player.getgender())
+			{
+				case 0:
+				{
+					mug = "STF";
+					break;
+				}
+				case 1: 
+				{
+					mug = "SFF";
+					break;
+				}
+				default: 
+				{
+					mug = "STC";
+					break;
+				}
+			}
+		}
+		else 
+		{
+			mug = plr.mugshot;
+		}
+		
+		string suffix = "ST"..(4 - min(plr.health / 20, 4)).."1";
+		if (plr.health < 1)
+		{
+			suffix = "DEAD0";
+		}
+		
+		sb.DrawTexture(texman.checkfortexture(mug..suffix), drawpos, flags, 1, (-1, -1), (0.4, 0.4));
+	}
+	
 	// [Ace] Copy-pasted from HD.
 	private ui void DrawHealthTicker(BaseStatusBar sb, HDPlayerPawn plr, vector2 drawpos, int flags)
 	{

--- a/cvarinfo.txt
+++ b/cvarinfo.txt
@@ -1,0 +1,3 @@
+user bool cl_buddyekg = true;
+user bool cl_buddybulk = true;
+user bool cl_buddymug = true;


### PR DESCRIPTION
Adds a display of each player's mugshot next to the EKG and bulk readout, as well as three cvars (cl_buddyekg, cl_buddybulk, cl_buddymug) that lets them be toggled.